### PR TITLE
add 3d transform to fix ios issue

### DIFF
--- a/src/styles/_animatedscroll.scss
+++ b/src/styles/_animatedscroll.scss
@@ -33,7 +33,8 @@
   box-sizing: border-box;
   height: calc(100vh - #{$sticky-header-height});
   width: 100%;
-  z-index: 2;
+  z-index: 10;
+  -webkit-transform: translate3d(0,0,0);
 }
 
 // step content overlapping map


### PR DESCRIPTION
# Changes
- adds `-webkit-transform: translate3d(0,0,0);` to step content elements to fix disappearing bug (fix found [here](https://css-tricks.com/forums/topic/safari-for-ios-z-index-ordering-bug-while-scrolling-a-page-with-a-fixed-element/))

closes #16 